### PR TITLE
2 methods should accept numbers

### DIFF
--- a/src/FixedPrecision.ts
+++ b/src/FixedPrecision.ts
@@ -110,7 +110,7 @@ export default class FixedPrecision {
     }
   }
 
-   /**
+  /**
    * Creates an immutable precision factory. Each factory returns instances
    * bound to its own places and rounding mode, avoiding global mutable state.
    *
@@ -158,11 +158,8 @@ export default class FixedPrecision {
    * @returns A new FixedPrecision instance with the internal value set to rawValue.
    */
   protected fromRaw(rawValue: bigint): FixedPrecision {
-    // const instance = new FixedPrecision(0n,this.ctx);
-    // instance.value = rawValue;
-    const instance = Object.create(FixedPrecision.prototype);
+    const instance = new FixedPrecision(0n, this.ctx);
     instance.value = rawValue;
-    instance.ctx = this.ctx;
     return instance;
   }
 
@@ -170,6 +167,15 @@ export default class FixedPrecision {
     if (this.ctx.places !== other.ctx.places) {
       throw new Error("Cannot operate on different precisions");
     }
+  }
+
+  private coerce(value: FixedPrecisionValue): FixedPrecision {
+    if (value instanceof FixedPrecision) {
+      this.assertSameConfig(value);
+      return value;
+    }
+
+    return new FixedPrecision(value, this.ctx);
   }
 
   // ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––

--- a/src/FixedPrecision.ts
+++ b/src/FixedPrecision.ts
@@ -400,9 +400,9 @@ export default class FixedPrecision {
   }
 
   /** Returns a FixedPrecision whose value is this FixedPrecision plus n. */
-  public add(other: FixedPrecision): FixedPrecision {
-    this.assertSameConfig(other);
-    return this.fromRaw(this.value + other.value);
+  public add(other: FixedPrecisionValue): FixedPrecision {
+    const o = this.coerce(other);
+    return this.fromRaw(this.value + o.value);
   }
 
   /** Alias for add. */
@@ -411,9 +411,9 @@ export default class FixedPrecision {
   }
 
   /** Returns a FixedPrecision whose value is this FixedPrecision minus n. */
-  public sub(other: FixedPrecision): FixedPrecision {
-    this.assertSameConfig(other);
-    return this.fromRaw(this.value - other.value);
+  public sub(other: FixedPrecisionValue): FixedPrecision {
+    const o = this.coerce(other);
+    return this.fromRaw(this.value - o.value);
   }
 
   /** Alias for sub. */
@@ -422,19 +422,19 @@ export default class FixedPrecision {
   }
 
   /** Returns a FixedPrecision whose value is this FixedPrecision times n. */
-  public mul(other: FixedPrecision): FixedPrecision {
-    this.assertSameConfig(other);
-    return this.fromRaw((this.value * other.value) / this.ctx.SCALE);
+  public mul(other: FixedPrecisionValue): FixedPrecision {
+    const o = this.coerce(other);
+    return this.fromRaw((this.value * o.value) / this.ctx.SCALE);
   }
 
   public product(other: FixedPrecision): FixedPrecision {
     return new FixedPrecision(this.value * other.value, this.ctx);
   }
 
-  /** Returns a FixedDecimal whose value is this FixedDecimal divided by n. */
-  public div(other: FixedPrecision): FixedPrecision {
-    this.assertSameConfig(other);
-    return this.fromRaw((this.value * this.ctx.SCALE) / other.value);
+  /** Returns a FixedPrecision whose value is this FixedPrecision divided by n. */
+  public div(other: FixedPrecisionValue): FixedPrecision {
+    const o = this.coerce(other);
+    return this.fromRaw((this.value * this.ctx.SCALE) / o.value);
   }
 
   public fraction(other: FixedPrecision): FixedPrecision {
@@ -442,9 +442,9 @@ export default class FixedPrecision {
   }
 
   /** Returns a FixedPrecision representing the integer remainder of dividing this by n. */
-  public mod(other: FixedPrecision): FixedPrecision {
-    this.assertSameConfig(other);
-    return this.fromRaw((this.value * this.ctx.SCALE) % other.value);
+  public mod(other: FixedPrecisionValue): FixedPrecision {
+    const o = this.coerce(other);
+    return this.fromRaw((this.value * this.ctx.SCALE) % o.value);
   }
   public leftover(other: FixedPrecision): FixedPrecision {
     return this.fromRaw(this.value % other.value);

--- a/src/FixedPrecision.ts
+++ b/src/FixedPrecision.ts
@@ -417,8 +417,8 @@ export default class FixedPrecision {
   }
 
   /** Alias for sub. */
-  public minus(other: FixedPrecision): FixedPrecision {
-    return this.sub(other);
+  public minus(other: FixedPrecisionValue): FixedPrecision {
+    return this.fromRaw(this.value - new FixedPrecision(other, this.ctx).value);
   }
 
   /** Returns a FixedPrecision whose value is this FixedPrecision times n. */
@@ -427,8 +427,8 @@ export default class FixedPrecision {
     return this.fromRaw((this.value * o.value) / this.ctx.SCALE);
   }
 
-  public product(other: FixedPrecision): FixedPrecision {
-    return new FixedPrecision(this.value * other.value, this.ctx);
+  public product(other: FixedPrecisionValue): FixedPrecision {
+    return this.fromRaw(this.value * new FixedPrecision(other, this.ctx).value);
   }
 
   /** Returns a FixedPrecision whose value is this FixedPrecision divided by n. */
@@ -437,8 +437,8 @@ export default class FixedPrecision {
     return this.fromRaw((this.value * this.ctx.SCALE) / o.value);
   }
 
-  public fraction(other: FixedPrecision): FixedPrecision {
-    return this.fromRaw(this.value / other.value);
+  public fraction(other: FixedPrecisionValue): FixedPrecision {
+    return this.fromRaw(this.value / new FixedPrecision(other, this.ctx).value);
   }
 
   /** Returns a FixedPrecision representing the integer remainder of dividing this by n. */
@@ -446,8 +446,8 @@ export default class FixedPrecision {
     const o = this.coerce(other);
     return this.fromRaw((this.value * this.ctx.SCALE) % o.value);
   }
-  public leftover(other: FixedPrecision): FixedPrecision {
-    return this.fromRaw(this.value % other.value);
+  public leftover(other: FixedPrecisionValue): FixedPrecision {
+    return this.fromRaw(this.value % new FixedPrecision(other, this.ctx).value);
   }
 
   /** Returns a FixedPrecision whose value is the negation of this FixedPrecision. */

--- a/src/FixedPrecision.ts
+++ b/src/FixedPrecision.ts
@@ -350,41 +350,41 @@ export default class FixedPrecision {
   /** Compares the values.
    *  Returns -1 if this < other, 0 if equal, and 1 if this > other.
    */
-  public cmp(other: FixedPrecision): Comparison {
-    this.assertSameConfig(other);
-    if (this.value < other.value) return -1;
-    if (this.value > other.value) return 1;
+  public cmp(other: FixedPrecisionValue): Comparison {
+    const o = this.coerce(other);
+    if (this.value < o.value) return -1;
+    if (this.value > o.value) return 1;
     return 0;
   }
 
   /** Returns true if this FixedPrecision equals other. */
-  public eq(other: FixedPrecision): boolean {
-    this.assertSameConfig(other);
-    return this.value === other.value;
+  public eq(other: FixedPrecisionValue): boolean {
+    const o = this.coerce(other);
+    return this.value === o.value;
   }
 
   /** Returns true if this FixedPrecision is greater than other. */
-  public gt(other: FixedPrecision): boolean {
-    this.assertSameConfig(other);
-    return this.value > other.value;
+  public gt(other: FixedPrecisionValue): boolean {
+    const o = this.coerce(other);
+    return this.value > o.value;
   }
 
   /** Returns true if this FixedPrecision is greater than or equal to other. */
-  public gte(other: FixedPrecision): boolean {
-    this.assertSameConfig(other);
-    return this.value >= other.value;
+  public gte(other: FixedPrecisionValue): boolean {
+    const o = this.coerce(other);
+    return this.value >= o.value;
   }
 
   /** Returns true if this FixedPrecision is less than other. */
-  public lt(other: FixedPrecision): boolean {
-    this.assertSameConfig(other);
-    return this.value < other.value;
+  public lt(other: FixedPrecisionValue): boolean {
+    const o = this.coerce(other);
+    return this.value < o.value;
   }
 
   /** Returns true if this FixedPrecision is less than or equal to other. */
-  public lte(other: FixedPrecision): boolean {
-    this.assertSameConfig(other);
-    return this.value <= other.value;
+  public lte(other: FixedPrecisionValue): boolean {
+    const o = this.coerce(other);
+    return this.value <= o.value;
   }
 
   public isZero(): boolean {


### PR DESCRIPTION
### Summary
This PR enhances the FixedPrecision library by allowing arithmetic and comparison operations to accept raw numbers (strings, numbers, bigints) in addition to FixedPrecision instances. This enables cleaner, more concise code through method chaining without requiring explicit FixedPrecision instantiation for every operand.
## Problem
Currently, arithmetic operations require both operands to be FixedPrecision instances:
```js
new FixedPrecision(10.5).add(new FixedPrecision(5)).div(new FixedPrecision(3)).toNumber();
```
This creates unnecessary verbosity and reduces code readability.
## Solution
Update all arithmetic and comparison methods to accept FixedPrecisionValue (which includes `string | number | bigint | FixedPrecision`) instead of only FixedPrecision instances. This allows:
```js 
new FixedPrecision(10.5).add(5).div(3).toNumber();
```
## Changes Made
1. Updated Method Signatures
All arithmetic and comparison methods now accept FixedPrecisionValue:
- Arithmetic: `add()`, `sub()`, `mul()`, `div()`, `mod()`, `plus()`, `minus()`, `product()`, `fraction()`, `leftover()`
- Comparison: `cmp()`, `eq()`, `gt()`, `gte()`, `lt()`, `lte()`
2. Internal `coerce()` Method
Added a private `coerce()` method that:
- Validates configuration compatibility for FixedPrecision instances
- Automatically converts raw values (string/number/bigint) to FixedPrecision with the current instance's context
- Maintains type safety and precision consistency
3. Backwards Compatibility

- [x] - All existing code using FixedPrecision instances continues to work unchanged
- [x] - No breaking changes to public API
- [x] - All existing tests pass without modification